### PR TITLE
feat: add Category entity with full CRUD, book linkage, and role-based access

### DIFF
--- a/src/main/java/bookrepo/controller/CategoryController.java
+++ b/src/main/java/bookrepo/controller/CategoryController.java
@@ -1,0 +1,84 @@
+package bookrepo.controller;
+
+import bookrepo.dto.book.BookDtoWithoutCategoryIds;
+import bookrepo.dto.category.CategoryDto;
+import bookrepo.exception.EntityNotFoundException;
+import bookrepo.mapper.BookMapper;
+import bookrepo.model.Book;
+import bookrepo.model.Category;
+import bookrepo.repository.book.BookRepository;
+import bookrepo.repository.category.CategoryRepository;
+import bookrepo.service.CategoryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+@Tag(name = "Category Controller", description = "Endpoints for managing categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+    private final BookRepository bookRepository;
+    private final BookMapper bookMapper;
+    private final CategoryRepository categoryRepository;
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CategoryDto createCategory(@RequestBody @Valid CategoryDto categoryDto) {
+        return categoryService.save(categoryDto);
+    }
+
+    @PreAuthorize("hasAuthority('USER')")
+    @GetMapping
+    public List<CategoryDto> getAll() {
+        return categoryService.findAll();
+    }
+
+    @PreAuthorize("hasAuthority('USER')")
+    @GetMapping("/{id}")
+    public CategoryDto getCategoryById(@PathVariable Long id) {
+        return categoryService.getById(id);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @PutMapping("/{id}")
+    public CategoryDto updateCategory(@PathVariable Long id,
+                                      @RequestBody @Valid CategoryDto categoryDto) {
+        return categoryService.update(id, categoryDto);
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteCategory(@PathVariable Long id) {
+        categoryService.deleteById(id);
+    }
+
+    @PreAuthorize("hasAuthority('USER')")
+    @GetMapping("/{id}/books")
+    public List<BookDtoWithoutCategoryIds> getBooksByCategoryId(@PathVariable Long id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() ->
+                        new EntityNotFoundException("Category not found with id: " + id));
+        List<Book> books = bookRepository.findAllByCategories_Id(id);
+        return books.stream()
+                .map(bookMapper::toDtoWithoutCategories)
+                .toList();
+
+    }
+
+}

--- a/src/main/java/bookrepo/controller/CategoryController.java
+++ b/src/main/java/bookrepo/controller/CategoryController.java
@@ -2,17 +2,14 @@ package bookrepo.controller;
 
 import bookrepo.dto.book.BookDtoWithoutCategoryIds;
 import bookrepo.dto.category.CategoryDto;
-import bookrepo.exception.EntityNotFoundException;
-import bookrepo.mapper.BookMapper;
-import bookrepo.model.Book;
-import bookrepo.model.Category;
-import bookrepo.repository.book.BookRepository;
-import bookrepo.repository.category.CategoryRepository;
+import bookrepo.service.BookService;
 import bookrepo.service.CategoryService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,9 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Category Controller", description = "Endpoints for managing categories")
 public class CategoryController {
     private final CategoryService categoryService;
-    private final BookRepository bookRepository;
-    private final BookMapper bookMapper;
-    private final CategoryRepository categoryRepository;
+    private final BookService bookService;
 
     @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
@@ -44,8 +39,8 @@ public class CategoryController {
 
     @PreAuthorize("hasAuthority('USER')")
     @GetMapping
-    public List<CategoryDto> getAll() {
-        return categoryService.findAll();
+    public Page<CategoryDto> getAll(Pageable pageable) {
+        return categoryService.findAll(pageable);
     }
 
     @PreAuthorize("hasAuthority('USER')")
@@ -71,14 +66,6 @@ public class CategoryController {
     @PreAuthorize("hasAuthority('USER')")
     @GetMapping("/{id}/books")
     public List<BookDtoWithoutCategoryIds> getBooksByCategoryId(@PathVariable Long id) {
-        Category category = categoryRepository.findById(id)
-                .orElseThrow(() ->
-                        new EntityNotFoundException("Category not found with id: " + id));
-        List<Book> books = bookRepository.findAllByCategories_Id(id);
-        return books.stream()
-                .map(bookMapper::toDtoWithoutCategories)
-                .toList();
-
+        return bookService.findAllByCategoryId(id);
     }
-
 }

--- a/src/main/java/bookrepo/controller/CategoryController.java
+++ b/src/main/java/bookrepo/controller/CategoryController.java
@@ -13,7 +13,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/categories")
@@ -26,28 +34,32 @@ public class CategoryController {
     @PostMapping
     @PreAuthorize("hasAuthority('ADMIN')")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "Create category", description = "Creates a new category. Requires ADMIN role.")
+    @Operation(summary = "Create category",
+            description = "Creates a new category. Requires ADMIN role.")
     public CategoryDto createCategory(@RequestBody @Valid CategoryDto categoryDto) {
         return categoryService.save(categoryDto);
     }
 
     @GetMapping
     @PreAuthorize("hasAuthority('USER')")
-    @Operation(summary = "Get all categories", description = "Returns paginated list of categories. Requires USER role.")
+    @Operation(summary = "Get all categories",
+            description = "Returns paginated list of categories. Requires USER role.")
     public Page<CategoryDto> getAll(Pageable pageable) {
         return categoryService.findAll(pageable);
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('USER')")
-    @Operation(summary = "Get category by ID", description = "Returns category by ID. Requires USER role.")
+    @Operation(summary = "Get category by ID",
+            description = "Returns category by ID. Requires USER role.")
     public CategoryDto getCategoryById(@PathVariable Long id) {
         return categoryService.getById(id);
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('ADMIN')")
-    @Operation(summary = "Update category", description = "Updates category by ID. Requires ADMIN role.")
+    @Operation(summary = "Update category",
+            description = "Updates category by ID. Requires ADMIN role.")
     public CategoryDto updateCategory(@PathVariable Long id,
                                       @RequestBody @Valid CategoryDto categoryDto) {
         return categoryService.update(id, categoryDto);
@@ -56,14 +68,16 @@ public class CategoryController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(summary = "Delete category", description = "Deletes category by ID. Requires ADMIN role.")
+    @Operation(summary = "Delete category",
+            description = "Deletes category by ID. Requires ADMIN role.")
     public void deleteCategory(@PathVariable Long id) {
         categoryService.deleteById(id);
     }
 
     @GetMapping("/{id}/books")
     @PreAuthorize("hasAuthority('USER')")
-    @Operation(summary = "Get books by category", description = "Returns books linked to category. Requires USER role.")
+    @Operation(summary = "Get books by category",
+            description = "Returns books linked to category. Requires USER role.")
     public List<BookDtoWithoutCategoryIds> getBooksByCategoryId(@PathVariable Long id) {
         return bookService.findAllByCategoryId(id);
     }

--- a/src/main/java/bookrepo/controller/CategoryController.java
+++ b/src/main/java/bookrepo/controller/CategoryController.java
@@ -4,6 +4,7 @@ import bookrepo.dto.book.BookDtoWithoutCategoryIds;
 import bookrepo.dto.category.CategoryDto;
 import bookrepo.service.BookService;
 import bookrepo.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -12,59 +13,57 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/categories")
 @RequiredArgsConstructor
-@Tag(name = "Category Controller", description = "Endpoints for managing categories")
+@Tag(name = "Category", description = "Endpoints for managing categories and related books")
 public class CategoryController {
     private final CategoryService categoryService;
     private final BookService bookService;
 
-    @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
+    @PreAuthorize("hasAuthority('ADMIN')")
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create category", description = "Creates a new category. Requires ADMIN role.")
     public CategoryDto createCategory(@RequestBody @Valid CategoryDto categoryDto) {
         return categoryService.save(categoryDto);
     }
 
-    @PreAuthorize("hasAuthority('USER')")
     @GetMapping
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Get all categories", description = "Returns paginated list of categories. Requires USER role.")
     public Page<CategoryDto> getAll(Pageable pageable) {
         return categoryService.findAll(pageable);
     }
 
-    @PreAuthorize("hasAuthority('USER')")
     @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Get category by ID", description = "Returns category by ID. Requires USER role.")
     public CategoryDto getCategoryById(@PathVariable Long id) {
         return categoryService.getById(id);
     }
 
-    @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @Operation(summary = "Update category", description = "Updates category by ID. Requires ADMIN role.")
     public CategoryDto updateCategory(@PathVariable Long id,
                                       @RequestBody @Valid CategoryDto categoryDto) {
         return categoryService.update(id, categoryDto);
     }
 
-    @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Delete category", description = "Deletes category by ID. Requires ADMIN role.")
     public void deleteCategory(@PathVariable Long id) {
         categoryService.deleteById(id);
     }
 
-    @PreAuthorize("hasAuthority('USER')")
     @GetMapping("/{id}/books")
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Get books by category", description = "Returns books linked to category. Requires USER role.")
     public List<BookDtoWithoutCategoryIds> getBooksByCategoryId(@PathVariable Long id) {
         return bookService.findAllByCategoryId(id);
     }

--- a/src/main/java/bookrepo/dto/book/BookDtoWithoutCategoryIds.java
+++ b/src/main/java/bookrepo/dto/book/BookDtoWithoutCategoryIds.java
@@ -1,11 +1,10 @@
 package bookrepo.dto.book;
 
 import java.math.BigDecimal;
-import java.util.Set;
 import lombok.Data;
 
 @Data
-public class BookDto {
+public class BookDtoWithoutCategoryIds {
     private Long id;
     private String title;
     private String author;
@@ -13,5 +12,4 @@ public class BookDto {
     private BigDecimal price;
     private String description;
     private String coverImage;
-    private Set<Long> categoryIds;
 }

--- a/src/main/java/bookrepo/dto/book/CreateBookRequestDto.java
+++ b/src/main/java/bookrepo/dto/book/CreateBookRequestDto.java
@@ -2,9 +2,11 @@ package bookrepo.dto.book;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import java.util.Set;
 import lombok.Data;
 
 @Data
@@ -21,4 +23,6 @@ public class CreateBookRequestDto {
     private BigDecimal price;
     private String description;
     private String coverImage;
+    @NotEmpty
+    private Set<Long> categoryIds;
 }

--- a/src/main/java/bookrepo/dto/category/CategoryDto.java
+++ b/src/main/java/bookrepo/dto/category/CategoryDto.java
@@ -1,0 +1,10 @@
+package bookrepo.dto.category;
+
+import lombok.Data;
+
+@Data
+public class CategoryDto {
+    private Long id;
+    private String name;
+    private String description;
+}

--- a/src/main/java/bookrepo/mapper/BookMapper.java
+++ b/src/main/java/bookrepo/mapper/BookMapper.java
@@ -2,8 +2,13 @@ package bookrepo.mapper;
 
 import bookrepo.config.MapperConfig;
 import bookrepo.dto.book.BookDto;
+import bookrepo.dto.book.BookDtoWithoutCategoryIds;
 import bookrepo.dto.book.CreateBookRequestDto;
 import bookrepo.model.Book;
+import bookrepo.model.Category;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 
@@ -14,4 +19,14 @@ public interface BookMapper {
     Book toModel(CreateBookRequestDto requestDto);
 
     void updateModelFromDto(CreateBookRequestDto requestDto, @MappingTarget Book book);
+
+    BookDtoWithoutCategoryIds toDtoWithoutCategories(Book book);
+
+    @AfterMapping
+    default void setCategoryIds(@MappingTarget BookDto bookDto, Book book) {
+        Set<Long> ids = book.getCategories().stream()
+                .map(Category::getId)
+                .collect(Collectors.toSet());
+        bookDto.setCategoryIds(ids);
+    }
 }

--- a/src/main/java/bookrepo/mapper/CategoryMapper.java
+++ b/src/main/java/bookrepo/mapper/CategoryMapper.java
@@ -1,0 +1,18 @@
+package bookrepo.mapper;
+
+import bookrepo.config.MapperConfig;
+import bookrepo.dto.category.CategoryDto;
+import bookrepo.model.Category;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(config = MapperConfig.class)
+public interface CategoryMapper {
+    CategoryDto toDto(Category category);
+
+    Category toEntity(CategoryDto categoryDto);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntityFromDto(CategoryDto categoryDto, @MappingTarget Category category);
+}

--- a/src/main/java/bookrepo/model/Book.java
+++ b/src/main/java/bookrepo/model/Book.java
@@ -5,8 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
@@ -38,6 +43,14 @@ public class Book {
     private String description;
 
     private String coverImage;
+
+    @ManyToMany
+    @JoinTable(
+            name = "books_categories",
+            joinColumns = @JoinColumn(name = "book_id"),
+            inverseJoinColumns = @JoinColumn(name = "category_id")
+    )
+    private Set<Category> categories = new HashSet<>();
 
     @Column(nullable = false)
     private boolean isDeleted = false;

--- a/src/main/java/bookrepo/model/Category.java
+++ b/src/main/java/bookrepo/model/Category.java
@@ -21,7 +21,7 @@ public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
     private String description;
     @Column(nullable = false)

--- a/src/main/java/bookrepo/model/Category.java
+++ b/src/main/java/bookrepo/model/Category.java
@@ -1,0 +1,29 @@
+package bookrepo.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@Setter
+@SQLDelete(sql = "UPDATE categories SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+@Table(name = "categories")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    private String description;
+    @Column(nullable = false)
+    private boolean isDeleted;
+}

--- a/src/main/java/bookrepo/repository/book/BookRepository.java
+++ b/src/main/java/bookrepo/repository/book/BookRepository.java
@@ -1,8 +1,10 @@
 package bookrepo.repository.book;
 
 import bookrepo.model.Book;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificationExecutor<Book> {
+    List<Book> findAllByCategories_Id(Long categoryId);
 }

--- a/src/main/java/bookrepo/repository/category/CategoryRepository.java
+++ b/src/main/java/bookrepo/repository/category/CategoryRepository.java
@@ -1,0 +1,7 @@
+package bookrepo.repository.category;
+
+import bookrepo.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/bookrepo/service/BookService.java
+++ b/src/main/java/bookrepo/service/BookService.java
@@ -1,6 +1,7 @@
 package bookrepo.service;
 
 import bookrepo.dto.book.BookDto;
+import bookrepo.dto.book.BookDtoWithoutCategoryIds;
 import bookrepo.dto.book.BookSearchParameters;
 import bookrepo.dto.book.CreateBookRequestDto;
 import java.util.List;
@@ -19,4 +20,6 @@ public interface BookService {
     void deleteById(Long id);
 
     List<BookDto> search(BookSearchParameters params);
+
+    List<BookDtoWithoutCategoryIds> findAllByCategoryId(Long id);
 }

--- a/src/main/java/bookrepo/service/CategoryService.java
+++ b/src/main/java/bookrepo/service/CategoryService.java
@@ -1,0 +1,17 @@
+package bookrepo.service;
+
+import bookrepo.dto.category.CategoryDto;
+import java.util.List;
+
+public interface CategoryService {
+    List<CategoryDto> findAll();
+
+    CategoryDto getById(Long id);
+
+    CategoryDto save(CategoryDto categoryDto);
+
+    CategoryDto update(Long id, CategoryDto categoryDto);
+
+    void deleteById(Long id);
+
+}

--- a/src/main/java/bookrepo/service/CategoryService.java
+++ b/src/main/java/bookrepo/service/CategoryService.java
@@ -1,10 +1,11 @@
 package bookrepo.service;
 
 import bookrepo.dto.category.CategoryDto;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CategoryService {
-    List<CategoryDto> findAll();
+    Page<CategoryDto> findAll(Pageable pageable);
 
     CategoryDto getById(Long id);
 

--- a/src/main/java/bookrepo/service/impl/BookServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/BookServiceImpl.java
@@ -16,7 +16,6 @@ import jakarta.transaction.Transactional;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,13 +33,13 @@ public class BookServiceImpl implements BookService {
     @Override
     public BookDto save(CreateBookRequestDto requestDto) {
         Book book = bookMapper.toModel(requestDto);
-        Set<Category> categories = new HashSet<>(categoryRepository.findAllById(requestDto.getCategoryIds()));
+        Set<Category> categories =
+                new HashSet<>(categoryRepository.findAllById(requestDto.getCategoryIds()));
         book.setCategories(categories);
 
         bookRepository.save(book);
         return bookMapper.toDto(book);
     }
-
 
     @Override
     public Page<BookDto> findAll(Pageable pageable) {
@@ -61,13 +60,13 @@ public class BookServiceImpl implements BookService {
                 .orElseThrow(() -> new EntityNotFoundException("Can't find book by id: " + id));
 
         bookMapper.updateModelFromDto(requestDto, book);
-        Set<Category> categories = new HashSet<>(categoryRepository.findAllById(requestDto.getCategoryIds()));
+        Set<Category> categories =
+                new HashSet<>(categoryRepository.findAllById(requestDto.getCategoryIds()));
         book.setCategories(categories);
 
         bookRepository.save(book);
         return bookMapper.toDto(book);
     }
-
 
     @Override
     public void deleteById(Long id) {

--- a/src/main/java/bookrepo/service/impl/BookServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/BookServiceImpl.java
@@ -13,7 +13,10 @@ import bookrepo.repository.book.BookSpecificationBuilder;
 import bookrepo.repository.category.CategoryRepository;
 import bookrepo.service.BookService;
 import jakarta.transaction.Transactional;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,9 +34,13 @@ public class BookServiceImpl implements BookService {
     @Override
     public BookDto save(CreateBookRequestDto requestDto) {
         Book book = bookMapper.toModel(requestDto);
+        Set<Category> categories = new HashSet<>(categoryRepository.findAllById(requestDto.getCategoryIds()));
+        book.setCategories(categories);
+
         bookRepository.save(book);
         return bookMapper.toDto(book);
     }
+
 
     @Override
     public Page<BookDto> findAll(Pageable pageable) {
@@ -52,10 +59,15 @@ public class BookServiceImpl implements BookService {
     public BookDto update(Long id, CreateBookRequestDto requestDto) {
         Book book = bookRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Can't find book by id: " + id));
+
         bookMapper.updateModelFromDto(requestDto, book);
+        Set<Category> categories = new HashSet<>(categoryRepository.findAllById(requestDto.getCategoryIds()));
+        book.setCategories(categories);
+
         bookRepository.save(book);
         return bookMapper.toDto(book);
     }
+
 
     @Override
     public void deleteById(Long id) {

--- a/src/main/java/bookrepo/service/impl/BookServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/BookServiceImpl.java
@@ -9,6 +9,7 @@ import bookrepo.model.Book;
 import bookrepo.repository.book.BookRepository;
 import bookrepo.repository.book.BookSpecificationBuilder;
 import bookrepo.service.BookService;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class BookServiceImpl implements BookService {
     private final BookRepository bookRepository;

--- a/src/main/java/bookrepo/service/impl/BookServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/BookServiceImpl.java
@@ -1,13 +1,16 @@
 package bookrepo.service.impl;
 
 import bookrepo.dto.book.BookDto;
+import bookrepo.dto.book.BookDtoWithoutCategoryIds;
 import bookrepo.dto.book.BookSearchParameters;
 import bookrepo.dto.book.CreateBookRequestDto;
 import bookrepo.exception.EntityNotFoundException;
 import bookrepo.mapper.BookMapper;
 import bookrepo.model.Book;
+import bookrepo.model.Category;
 import bookrepo.repository.book.BookRepository;
 import bookrepo.repository.book.BookSpecificationBuilder;
+import bookrepo.repository.category.CategoryRepository;
 import bookrepo.service.BookService;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -23,6 +26,7 @@ public class BookServiceImpl implements BookService {
     private final BookRepository bookRepository;
     private final BookMapper bookMapper;
     private final BookSpecificationBuilder bookSpecificationBuilder;
+    private final CategoryRepository categoryRepository;
 
     @Override
     public BookDto save(CreateBookRequestDto requestDto) {
@@ -63,6 +67,17 @@ public class BookServiceImpl implements BookService {
         return bookRepository.findAll(bookSpecificationBuilder.build(params))
                 .stream()
                 .map(bookMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public List<BookDtoWithoutCategoryIds> findAllByCategoryId(Long id) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() ->
+                        new EntityNotFoundException("Category not found with id: " + id));
+        List<Book> books = bookRepository.findAllByCategories_Id(id);
+        return books.stream()
+                .map(bookMapper::toDtoWithoutCategories)
                 .toList();
     }
 }

--- a/src/main/java/bookrepo/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/CategoryServiceImpl.java
@@ -1,0 +1,53 @@
+package bookrepo.service.impl;
+
+import bookrepo.dto.category.CategoryDto;
+import bookrepo.exception.EntityNotFoundException;
+import bookrepo.mapper.CategoryMapper;
+import bookrepo.model.Category;
+import bookrepo.repository.category.CategoryRepository;
+import bookrepo.service.CategoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    @Override
+    public List<CategoryDto> findAll() {
+        return categoryRepository.findAll().stream()
+                .map(categoryMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public CategoryDto getById(Long id) {
+        return categoryMapper.toDto(categoryRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException("Can't find category by id: " + id)
+        ));
+    }
+
+    @Override
+    public CategoryDto save(CategoryDto categoryDto) {
+        Category category = categoryMapper.toEntity(categoryDto);
+        categoryRepository.save(category);
+        return categoryMapper.toDto(category);
+    }
+
+    @Override
+    public CategoryDto update(Long id, CategoryDto categoryDto) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Can't find category by id: " + id));
+        categoryMapper.updateEntityFromDto(categoryDto, category);
+        categoryRepository.save(category);
+        return categoryMapper.toDto(category);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        categoryRepository.deleteById(id);
+    }
+}

--- a/src/main/java/bookrepo/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/CategoryServiceImpl.java
@@ -6,8 +6,9 @@ import bookrepo.mapper.CategoryMapper;
 import bookrepo.model.Category;
 import bookrepo.repository.category.CategoryRepository;
 import bookrepo.service.CategoryService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,10 +18,9 @@ public class CategoryServiceImpl implements CategoryService {
     private final CategoryMapper categoryMapper;
 
     @Override
-    public List<CategoryDto> findAll() {
-        return categoryRepository.findAll().stream()
-                .map(categoryMapper::toDto)
-                .toList();
+    public Page<CategoryDto> findAll(Pageable pageable) {
+        return categoryRepository.findAll(pageable)
+                .map(categoryMapper::toDto);
     }
 
     @Override

--- a/src/main/resources/db/changelog/changes/05-create-categories-table.yaml
+++ b/src/main/resources/db/changelog/changes/05-create-categories-table.yaml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-categories-table
+      author: JlusS
+      changes:
+        - createTable:
+            tableName: categories
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: varchar(100)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: is_deleted
+                  type: tinyint(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: create-books-categories-table
+      author: JlusS
+      changes:
+        - createTable:
+            tableName: books_categories
+            columns:
+              - column:
+                  name: book_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: category_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: books_categories
+            columnNames: book_id, category_id
+        - addForeignKeyConstraint:
+            baseTableName: books_categories
+            baseColumnNames: book_id
+            referencedTableName: books
+            referencedColumnNames: id
+            constraintName: fk_books_categories_book
+        - addForeignKeyConstraint:
+            baseTableName: books_categories
+            baseColumnNames: category_id
+            referencedTableName: categories
+            referencedColumnNames: id
+            constraintName: fk_books_categories_category

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/changes/03-create-roles-table.yaml
   - include:
       file: db/changelog/changes/04-insert-roles.yaml
+  - include:
+      file: db/changelog/changes/05-create-categories-table.yaml


### PR DESCRIPTION
Introduced Category entity with fields: id, name, description
- Linked Category to Book via ManyToMany (Set<Category> in Book)
- Added CategoryRepository, DTOs, and CategoryMapper
- Extended BookMapper with category-aware DTOs and @AfterMapping logic
- Implemented CategoryService and CategoryServiceImpl with full CRUD
- Created CategoryController with endpoints:
    - POST /api/categories
    - GET /api/categories
    - GET /api/categories/{id}
    - PUT /api/categories/{id}
    - DELETE /api/categories/{id}
    - GET /api/categories/{id}/books
- Secured endpoints with role-based access (USER/ADMIN)
- Enabled pagination, sorting, and Swagger documentation
- Integrated Liquibase changelog for Category table
- Applied soft delete strategy to Category and Book entities