### PR TITLE
feat: implement order management and retrieval endpoints

### DIFF
--- a/src/main/java/bookrepo/controller/OrderController.java
+++ b/src/main/java/bookrepo/controller/OrderController.java
@@ -1,0 +1,72 @@
+package bookrepo.controller;
+
+import bookrepo.dto.order.CreateOrderDto;
+import bookrepo.dto.order.OrderDto;
+import bookrepo.dto.order.OrderItemDto;
+import bookrepo.dto.order.UpdateOrderStatusDto;
+import bookrepo.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+@Tag(name = "Order Controller", description = "Endpoints for managing orders and order items")
+public class OrderController {
+    private final OrderService orderService;
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @Operation(summary = "Get all orders", description =
+            "Returns a paginated list of all orders. Accessible only by ADMIN.")
+    public Page<OrderDto> getAllOrders(Pageable pageable) {
+        return orderService.getAllOrders(pageable);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Create a new order", description =
+            "Creates a new order for the authenticated USER.")
+    public OrderDto createOrder(@RequestBody @Valid CreateOrderDto orderDto) {
+        return orderService.save(orderDto);
+    }
+
+    @PatchMapping
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Update order status", description =
+            "Updates the status of an existing order. Accessible by USER.")
+    public OrderDto updateOrderStatus(
+            @RequestBody @Valid UpdateOrderStatusDto orderDto) {
+        return orderService.update(orderDto);
+    }
+
+    @GetMapping("/{id}/items")
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Get order items by order ID", description =
+            "Returns all items for a specific order. Accessible by USER.")
+    public OrderItemDto getOrderItems(@PathVariable Long id) {
+        return orderService.findByOrderId(id);
+    }
+
+    @GetMapping("/{orderId}/items/{itemId}")
+    @PreAuthorize("hasAuthority('USER')")
+    @Operation(summary = "Get specific order item", description =
+            "Returns a specific item from an order by order ID and item ID.")
+    public OrderItemDto getSpecificOrderItem(
+            @PathVariable Long orderId,
+            @PathVariable Long itemId) {
+        return orderService.findSpecificOrderItem(orderId, itemId);
+    }
+}

--- a/src/main/java/bookrepo/controller/OrderController.java
+++ b/src/main/java/bookrepo/controller/OrderController.java
@@ -8,6 +8,7 @@ import bookrepo.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,12 +53,12 @@ public class OrderController {
         return orderService.update(orderDto);
     }
 
-    @GetMapping("/{id}/items")
+    @GetMapping("/{orderId}/items")
     @PreAuthorize("hasAuthority('USER')")
     @Operation(summary = "Get order items by order ID", description =
             "Returns all items for a specific order. Accessible by USER.")
-    public OrderItemDto getOrderItems(@PathVariable Long id) {
-        return orderService.findByOrderId(id);
+    public List<OrderItemDto> getOrderItems(@PathVariable Long orderId) {
+        return orderService.findByOrderId(orderId);
     }
 
     @GetMapping("/{orderId}/items/{itemId}")

--- a/src/main/java/bookrepo/dto/order/CreateOrderDto.java
+++ b/src/main/java/bookrepo/dto/order/CreateOrderDto.java
@@ -1,0 +1,15 @@
+package bookrepo.dto.order;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+@Data
+public class CreateOrderDto {
+    private String shippingAddress;
+    @NotNull
+    @Positive
+    private Long bookId;
+    @Positive
+    private Integer quantity;
+}

--- a/src/main/java/bookrepo/dto/order/CreateOrderDto.java
+++ b/src/main/java/bookrepo/dto/order/CreateOrderDto.java
@@ -1,15 +1,10 @@
 package bookrepo.dto.order;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class CreateOrderDto {
+    @NotBlank
     private String shippingAddress;
-    @NotNull
-    @Positive
-    private Long bookId;
-    @Positive
-    private Integer quantity;
 }

--- a/src/main/java/bookrepo/dto/order/OrderDto.java
+++ b/src/main/java/bookrepo/dto/order/OrderDto.java
@@ -1,6 +1,5 @@
 package bookrepo.dto.order;
 
-import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import java.util.Set;
 import lombok.Data;
@@ -11,7 +10,6 @@ public class OrderDto {
     private Long userId;
     private Set<OrderItemDto> orderItems;
     private String orderDate;
-    @Positive
     private BigDecimal total;
     private String status;
 }

--- a/src/main/java/bookrepo/dto/order/OrderDto.java
+++ b/src/main/java/bookrepo/dto/order/OrderDto.java
@@ -1,0 +1,17 @@
+package bookrepo.dto.order;
+
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class OrderDto {
+    private Long id;
+    private Long userId;
+    private Set<OrderItemDto> orderItems;
+    private String orderDate;
+    @Positive
+    private BigDecimal total;
+    private String status;
+}

--- a/src/main/java/bookrepo/dto/order/OrderItemDto.java
+++ b/src/main/java/bookrepo/dto/order/OrderItemDto.java
@@ -1,0 +1,10 @@
+package bookrepo.dto.order;
+
+import lombok.Data;
+
+@Data
+public class OrderItemDto {
+    private Long id;
+    private Long bookId;
+    private int quantity;
+}

--- a/src/main/java/bookrepo/dto/order/UpdateOrderStatusDto.java
+++ b/src/main/java/bookrepo/dto/order/UpdateOrderStatusDto.java
@@ -1,8 +1,10 @@
 package bookrepo.dto.order;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class UpdateOrderStatusDto {
+    @NotBlank
     private String status;
 }

--- a/src/main/java/bookrepo/dto/order/UpdateOrderStatusDto.java
+++ b/src/main/java/bookrepo/dto/order/UpdateOrderStatusDto.java
@@ -1,0 +1,8 @@
+package bookrepo.dto.order;
+
+import lombok.Data;
+
+@Data
+public class UpdateOrderStatusDto {
+    private String status;
+}

--- a/src/main/java/bookrepo/mapper/OrderItemMapper.java
+++ b/src/main/java/bookrepo/mapper/OrderItemMapper.java
@@ -1,0 +1,12 @@
+package bookrepo.mapper;
+
+import bookrepo.dto.order.OrderItemDto;
+import bookrepo.model.OrderItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = BookMapper.class)
+public interface OrderItemMapper {
+    @Mapping(source = "book.id", target = "bookId")
+    OrderItemDto toDto(OrderItem orderItem);
+}

--- a/src/main/java/bookrepo/mapper/OrderMapper.java
+++ b/src/main/java/bookrepo/mapper/OrderMapper.java
@@ -1,0 +1,13 @@
+package bookrepo.mapper;
+
+import bookrepo.config.MapperConfig;
+import bookrepo.dto.order.OrderDto;
+import bookrepo.model.Order;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapperConfig.class, uses = OrderItemMapper.class)
+public interface OrderMapper {
+    @Mapping(source = "user.id", target = "userId")
+    OrderDto toDto(Order order);
+}

--- a/src/main/java/bookrepo/model/Order.java
+++ b/src/main/java/bookrepo/model/Order.java
@@ -1,0 +1,50 @@
+package bookrepo.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "orders")
+public class Order {
+    @Id
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "id")
+    private User user;
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private Status status;
+    @NotNull
+    private BigDecimal total;
+    @NotNull
+    private LocalDateTime orderDate;
+    @NotNull
+    private String shippingAddress;
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<OrderItem> orderItems = new HashSet<>();
+
+    public enum Status {
+        PENDING,
+        COMPLETED,
+        CANCELLED
+    }
+}

--- a/src/main/java/bookrepo/model/Order.java
+++ b/src/main/java/bookrepo/model/Order.java
@@ -1,17 +1,18 @@
 package bookrepo.model;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -25,19 +26,19 @@ import lombok.Setter;
 @Table(name = "orders")
 public class Order {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
     @Enumerated(EnumType.STRING)
-    @NotNull
+    @Column(nullable = false)
     private Status status;
-    @NotNull
+    @Column(nullable = false)
     private BigDecimal total;
-    @NotNull
+    @Column(nullable = false)
     private LocalDateTime orderDate;
-    @NotNull
+    @Column(nullable = false)
     private String shippingAddress;
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<OrderItem> orderItems = new HashSet<>();

--- a/src/main/java/bookrepo/model/OrderItem.java
+++ b/src/main/java/bookrepo/model/OrderItem.java
@@ -1,0 +1,45 @@
+package bookrepo.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@Setter
+@SQLDelete(sql = "UPDATE order_items SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+@Table(name = "order_items")
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+}

--- a/src/main/java/bookrepo/repository/order/OrderItemRepository.java
+++ b/src/main/java/bookrepo/repository/order/OrderItemRepository.java
@@ -1,17 +1,18 @@
 package bookrepo.repository.order;
 
 import bookrepo.model.OrderItem;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import java.math.BigDecimal;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
-    @Query("SELECT o FROM OrderItem o WHERE o.order.id = :orderId AND o.id = :itemId")
-    OrderItem findByIdAndOrderId(@Param("orderId") Long orderId, @Param("itemId") Long itemId);
+    @Query("SELECT oi FROM OrderItem oi "
+            + "WHERE oi.id =:itemId AND oi.order.id = :orderId "
+            + "AND oi.order.user.id = :userId")
+    OrderItem findByIdAndOrderIdAndUserId(@Param("orderId") Long orderId,
+                                          @Param("itemId") Long itemId,
+                                          @Param("userId") Long userId);
 
-    @NotNull
-    BigDecimal findByBookId(@NotNull @Positive Long bookId);
+    List<OrderItem> findAllByOrderId(Long orderId);
 }

--- a/src/main/java/bookrepo/repository/order/OrderItemRepository.java
+++ b/src/main/java/bookrepo/repository/order/OrderItemRepository.java
@@ -1,0 +1,17 @@
+package bookrepo.repository.order;
+
+import bookrepo.model.OrderItem;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    @Query("SELECT o FROM OrderItem o WHERE o.order.id = :orderId AND o.id = :itemId")
+    OrderItem findByIdAndOrderId(@Param("orderId") Long orderId, @Param("itemId") Long itemId);
+
+    @NotNull
+    BigDecimal findByBookId(@NotNull @Positive Long bookId);
+}

--- a/src/main/java/bookrepo/repository/order/OrderRepository.java
+++ b/src/main/java/bookrepo/repository/order/OrderRepository.java
@@ -1,0 +1,9 @@
+package bookrepo.repository.order;
+
+import bookrepo.model.Order;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    Optional<Order> findUserById(Long id);
+}

--- a/src/main/java/bookrepo/service/OrderService.java
+++ b/src/main/java/bookrepo/service/OrderService.java
@@ -4,10 +4,7 @@ import bookrepo.dto.order.CreateOrderDto;
 import bookrepo.dto.order.OrderDto;
 import bookrepo.dto.order.OrderItemDto;
 import bookrepo.dto.order.UpdateOrderStatusDto;
-import bookrepo.model.Book;
-import bookrepo.model.Order;
-import bookrepo.model.User;
-import java.math.BigDecimal;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -18,15 +15,9 @@ public interface OrderService {
 
     OrderDto update(UpdateOrderStatusDto orderDto);
 
-    OrderItemDto findByOrderId(Long id);
+    List<OrderItemDto> findByOrderId(Long id);
 
     OrderItemDto findSpecificOrderItem(Long orderId, Long itemId);
 
     void deleteById(Long id);
-
-    Order createOrder(User user, CreateOrderDto orderDto);
-
-    void createOrderItem(Book book, Order order, CreateOrderDto orderDto);
-
-    BigDecimal calculateTotal(Order order);
 }

--- a/src/main/java/bookrepo/service/OrderService.java
+++ b/src/main/java/bookrepo/service/OrderService.java
@@ -1,0 +1,32 @@
+package bookrepo.service;
+
+import bookrepo.dto.order.CreateOrderDto;
+import bookrepo.dto.order.OrderDto;
+import bookrepo.dto.order.OrderItemDto;
+import bookrepo.dto.order.UpdateOrderStatusDto;
+import bookrepo.model.Book;
+import bookrepo.model.Order;
+import bookrepo.model.User;
+import java.math.BigDecimal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderService {
+    Page<OrderDto> getAllOrders(Pageable pageable);
+
+    OrderDto save(CreateOrderDto orderDto);
+
+    OrderDto update(UpdateOrderStatusDto orderDto);
+
+    OrderItemDto findByOrderId(Long id);
+
+    OrderItemDto findSpecificOrderItem(Long orderId, Long itemId);
+
+    void deleteById(Long id);
+
+    Order createOrder(User user, CreateOrderDto orderDto);
+
+    void createOrderItem(Book book, Order order, CreateOrderDto orderDto);
+
+    BigDecimal calculateTotal(Order order);
+}

--- a/src/main/java/bookrepo/service/impl/OrderServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/OrderServiceImpl.java
@@ -1,0 +1,135 @@
+package bookrepo.service.impl;
+
+import bookrepo.dto.order.CreateOrderDto;
+import bookrepo.dto.order.OrderDto;
+import bookrepo.dto.order.OrderItemDto;
+import bookrepo.dto.order.UpdateOrderStatusDto;
+import bookrepo.exception.EntityNotFoundException;
+import bookrepo.mapper.OrderItemMapper;
+import bookrepo.mapper.OrderMapper;
+import bookrepo.model.Book;
+import bookrepo.model.Order;
+import bookrepo.model.OrderItem;
+import bookrepo.model.User;
+import bookrepo.repository.book.BookRepository;
+import bookrepo.repository.order.OrderItemRepository;
+import bookrepo.repository.order.OrderRepository;
+import bookrepo.security.AuthenticationService;
+import bookrepo.service.OrderService;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+    private final OrderRepository orderRepository;
+    private final OrderMapper orderMapper;
+    private final AuthenticationService authenticationService;
+    private final BookRepository bookRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final OrderItemMapper orderItemMapper;
+
+    @Override
+    public Page<OrderDto> getAllOrders(Pageable pageable) {
+        return orderRepository.findAll(pageable)
+                        .map(orderMapper::toDto);
+    }
+
+    @Override
+    public OrderDto save(CreateOrderDto orderDto) {
+        User user = authenticationService.getAuthenticatedUser();
+
+        Order order = orderRepository.findUserById(user.getId())
+                .orElseGet(() -> createOrder(user, orderDto));
+
+        Book book = bookRepository.findById(order.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Book: "
+                        + orderDto.getBookId()
+                        + " not found"));
+
+        Optional<OrderItem> existingOrderItem = order.getOrderItems().stream()
+                .filter(item -> item.getBook().getId().equals(book.getId()))
+                .findFirst();
+
+        if (existingOrderItem.isPresent()) {
+            existingOrderItem.get().setQuantity(
+                    existingOrderItem.get().getQuantity()
+                    + orderDto.getQuantity());
+        } else {
+            createOrderItem(book,order, orderDto);
+        }
+
+        orderRepository.save(order);
+        return orderMapper.toDto(order);
+    }
+
+    @Override
+    public OrderDto update(UpdateOrderStatusDto orderDto) {
+        User user = authenticationService.getAuthenticatedUser();
+
+        Order order = orderRepository.findUserById(user.getId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Order not found for user id: "
+                        + user.getId()));
+
+        order.setStatus(Order.Status.valueOf(orderDto.getStatus()));
+
+        orderRepository.save(order);
+        return orderMapper.toDto(order);
+    }
+
+    @Override
+    public OrderItemDto findByOrderId(Long id) {
+        return orderItemRepository.findById(id)
+                .map(orderItemMapper::toDto).orElseThrow(() -> new EntityNotFoundException(
+                        "Order item not found for id: "
+                        + id));
+    }
+
+    @Override
+    public OrderItemDto findSpecificOrderItem(Long orderId, Long itemId) {
+        OrderItem item = orderItemRepository.findByIdAndOrderId(orderId, itemId);
+        return orderItemMapper.toDto(item);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        orderRepository.deleteById(id);
+    }
+
+    @Override
+    public Order createOrder(User user, CreateOrderDto orderDto) {
+        Order order = new Order();
+        order.setUser(user);
+        order.setShippingAddress(orderDto.getShippingAddress());
+        order.setStatus(Order.Status.PENDING);
+        order.setOrderDate(LocalDateTime.now());
+        order.setTotal(calculateTotal(order));
+        orderRepository.save(order);
+        return order;
+    }
+
+    @Override
+    public void createOrderItem(Book book, Order order, CreateOrderDto orderDto) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setBook(book);
+        orderItem.setQuantity(orderDto.getQuantity());
+        orderItem.setOrder(order);
+        orderItem.setPrice(book.getPrice());
+        order.getOrderItems().add(orderItem);
+    }
+
+    @Override
+    public BigDecimal calculateTotal(Order order) {
+        return order.getOrderItems().stream()
+                .map(item -> item.getPrice().multiply(BigDecimal.valueOf(item.getQuantity())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+}

--- a/src/main/java/bookrepo/service/impl/OrderServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/OrderServiceImpl.java
@@ -111,9 +111,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public OrderItemDto findSpecificOrderItem(Long orderId, Long itemId) {
         User user = authenticationService.getAuthenticatedUser();
-        OrderItem item = Optional.ofNullable(
-                orderItemRepository.findByIdAndOrderIdAndUserId(orderId, itemId, user.getId())
-        ).orElseThrow(() -> new EntityNotFoundException("Order item not found"));
+        OrderItem item = orderItemRepository.findByIdAndOrderIdAndUserId(orderId, itemId, user.getId());
         return orderItemMapper.toDto(item);
     }
 

--- a/src/main/java/bookrepo/service/impl/OrderServiceImpl.java
+++ b/src/main/java/bookrepo/service/impl/OrderServiceImpl.java
@@ -21,7 +21,6 @@ import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -111,7 +110,8 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public OrderItemDto findSpecificOrderItem(Long orderId, Long itemId) {
         User user = authenticationService.getAuthenticatedUser();
-        OrderItem item = orderItemRepository.findByIdAndOrderIdAndUserId(orderId, itemId, user.getId());
+        OrderItem item = orderItemRepository
+                .findByIdAndOrderIdAndUserId(orderId, itemId, user.getId());
         return orderItemMapper.toDto(item);
     }
 

--- a/src/main/resources/db/changelog/changes/07-create-orders-table.yaml
+++ b/src/main/resources/db/changelog/changes/07-create-orders-table.yaml
@@ -1,0 +1,93 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-orders-table
+      author: Yehor
+      changes:
+        - createTable:
+            tableName: orders
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: status
+                  type: varchar(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: total
+                  type: decimal(19,2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: order_date
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: shipping_address
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: orders
+            baseColumnNames: id
+            referencedTableName: users
+            referencedColumnNames: id
+            constraintName: fk_order_user
+
+  - changeSet:
+      id: create-order-items-table
+      author: Yehor
+      changes:
+        - createTable:
+            tableName: order_items
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: order_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: book_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: quantity
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: price
+                  type: decimal(19,2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: is_deleted
+                  type: tinyint(1)
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: order_items
+            baseColumnNames: order_id
+            referencedTableName: orders
+            referencedColumnNames: id
+            constraintName: fk_order_item_order
+        - addForeignKeyConstraint:
+            baseTableName: order_items
+            baseColumnNames: book_id
+            referencedTableName: books
+            referencedColumnNames: id
+            constraintName: fk_order_item_book

--- a/src/main/resources/db/changelog/changes/07-create-orders-table.yaml
+++ b/src/main/resources/db/changelog/changes/07-create-orders-table.yaml
@@ -9,8 +9,14 @@ databaseChangeLog:
               - column:
                   name: id
                   type: bigint
+                  autoIncrement: true
                   constraints:
                     primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: bigint
+                  constraints:
                     nullable: false
               - column:
                   name: status
@@ -34,7 +40,7 @@ databaseChangeLog:
                     nullable: false
         - addForeignKeyConstraint:
             baseTableName: orders
-            baseColumnNames: id
+            baseColumnNames: user_id
             referencedTableName: users
             referencedColumnNames: id
             constraintName: fk_order_user

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -11,3 +11,5 @@ databaseChangeLog:
       file: db/changelog/changes/05-create-categories-table.yaml
   - include:
       file: db/changelog/changes/06-create-shopping-cart-table.yaml
+  - include:
+      file: db/changelog/changes/07-create-orders-table.yaml


### PR DESCRIPTION
- Added Order and OrderItem entities with full JPA mappings
- Implemented order placement via POST /api/orders
- Enabled order history retrieval via GET /api/orders
- Added nested endpoints for order items:
    - GET /api/orders/{orderId}/items
    - GET /api/orders/{orderId}/items/{itemId}
- Implemented order status update via PATCH /api/orders/{id}
- Secured endpoints based on user roles (USER, ADMIN)
- Annotated OrderController with Swagger @Tag and @Operation for OpenAPI docs